### PR TITLE
[SIG-19527] Treat Databricks SQL_(W)VARCHAR as SQL_(W)LONGVARCHAR

### DIFF
--- a/column.go
+++ b/column.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type BufferLen api.SQLLEN

--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Conn struct {

--- a/driver.go
+++ b/driver.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 var drv Driver

--- a/error.go
+++ b/error.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 func IsError(ret api.SQLRETURN) bool {

--- a/foxpro_test.go
+++ b/foxpro_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/polytomic/odbc"
+	_ "github.com/sigmacomputing/odbc"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/polytomic/odbc
+module github.com/sigmacomputing/odbc
 
 go 1.13
 

--- a/handle.go
+++ b/handle.go
@@ -7,7 +7,7 @@ package odbc
 import (
 	"fmt"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 func ToHandleAndType(handle interface{}) (h api.SQLHANDLE, ht api.SQLSMALLINT, err error) {

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 var (

--- a/odbcstmt.go
+++ b/odbcstmt.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 // TODO(brainman): see if I could use SQLExecDirect anywhere

--- a/param.go
+++ b/param.go
@@ -10,7 +10,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Parameter struct {

--- a/rows.go
+++ b/rows.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Rows struct {

--- a/stats.go
+++ b/stats.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Stats struct {

--- a/stmt.go
+++ b/stmt.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Stmt struct {

--- a/tx.go
+++ b/tx.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"errors"
 
-	"github.com/polytomic/odbc/api"
+	"github.com/sigmacomputing/odbc/api"
 )
 
 type Tx struct {


### PR DESCRIPTION
As a workaround for a Databricks ODBC driver bug, we treat `SQL_(W)VARCHAR` as `SQL_(W)LONGVARCHAR` (and `SQL_VARBINARY` as `SQL_LONGVARBINARY`). Specifically, the Simbaspark ODBC driver's `SQLDescribeCol` API always returns 256 bytes for the size of a `VARCHAR` column, regardless of its actual size. As such, we're effectively ignoring that value and treating it as a string of an unknown size.