### PR TITLE
Implement SessionResetter interface for Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -5,6 +5,7 @@
 package odbc
 
 import (
+	"context"
 	"database/sql/driver"
 	"strings"
 	"unsafe"
@@ -71,4 +72,13 @@ func (c *Conn) newError(apiName string, handle interface{}) error {
 		c.bad = true
 	}
 	return err
+}
+
+// Implement driver.SessionResetter interface for Conn, to discard connections that
+// have been marked as bad.
+func (c *Conn) ResetSession(_ context.Context) error {
+	if c.bad {
+		return driver.ErrBadConn
+	}
+	return nil
 }


### PR DESCRIPTION
Once a connection has been marked as `bad`, we don't want to return it to the connection pool. Implementing `ResetSession` allows us to force a connection to be reset (and thus not be reused) in this case.`