### PR TITLE
Use connection timezone when fetching column values

### DIFF
--- a/column.go
+++ b/column.go
@@ -53,7 +53,7 @@ func describeColumn(h api.SQLHSTMT, idx int, namebuf []uint16) (namelen int, sql
 
 // TODO(brainman): did not check for MS SQL timestamp
 
-func NewColumn(h api.SQLHSTMT, idx int) (Column, error) {
+func NewColumn(h api.SQLHSTMT, idx int, loc *time.Location) (Column, error) {
 	namebuf := make([]uint16, 150)
 	namelen, sqltype, size, nullable, ret := describeColumn(h, idx, namebuf)
 	if ret == api.SQL_SUCCESS_WITH_INFO && namelen > len(namebuf) {
@@ -70,6 +70,7 @@ func NewColumn(h api.SQLHSTMT, idx int) (Column, error) {
 	}
 	b := &BaseColumn{
 		name:     api.UTF16ToString(namebuf[:namelen]),
+		loc:      loc,
 		SQLType:  sqltype,
 		nullable: nullable,
 	}
@@ -122,6 +123,7 @@ func NewColumn(h api.SQLHSTMT, idx int) (Column, error) {
 // BaseColumn implements common column functionality.
 type BaseColumn struct {
 	name     string
+	loc      *time.Location
 	SQLType  api.SQLSMALLINT
 	CType    api.SQLSMALLINT
 	nullable api.SQLSMALLINT
@@ -139,6 +141,9 @@ func (c *BaseColumn) Value(buf []byte) (driver.Value, error) {
 	loc := time.UTC
 	if drv.Loc != nil {
 		loc = drv.Loc
+	}
+	if c.loc != nil {
+		loc = c.loc
 	}
 	switch c.CType {
 	case api.SQL_C_BIT:

--- a/odbcstmt.go
+++ b/odbcstmt.go
@@ -19,6 +19,7 @@ import (
 
 type ODBCStmt struct {
 	h          api.SQLHSTMT
+	loc        *time.Location
 	Parameters []Parameter
 	Cols       []Column
 	// locking/lifetime
@@ -52,6 +53,7 @@ func (c *Conn) PrepareODBCStmt(query string) (*ODBCStmt, error) {
 	}
 	return &ODBCStmt{
 		h:          h,
+		loc:        c.loc,
 		Parameters: ps,
 		usedByStmt: true,
 	}, nil
@@ -137,7 +139,7 @@ func (s *ODBCStmt) BindColumns() error {
 	s.Cols = make([]Column, n)
 	binding := true
 	for i := range s.Cols {
-		c, err := NewColumn(s.h, i)
+		c, err := NewColumn(s.h, i, s.loc)
 		if err != nil {
 			return err
 		}

--- a/tz.go
+++ b/tz.go
@@ -1,0 +1,25 @@
+package odbc
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Regex to extract timezone for Databricks.
+var tzRegex = regexp.MustCompile("SSP_timezone=(.*?);")
+
+// Extracts the value of the SSP_timezone key from the given DSN. Returns nil
+// if no timezone is specified, and an error if an invalid timezone is specified.
+func extractTimezoneFromDsn(dsn string) (*time.Location, error) {
+	matches := tzRegex.FindStringSubmatch(dsn)
+	if len(matches) < 2 {
+		return nil, nil
+	}
+
+	loc, err := time.LoadLocation(strings.TrimSpace(matches[1]))
+	if err != nil {
+		return nil, err
+	}
+	return loc, nil
+}

--- a/tz_test.go
+++ b/tz_test.go
@@ -1,0 +1,64 @@
+package odbc
+
+import (
+	"testing"
+	"time"
+)
+
+func loc(t *testing.T, name string) *time.Location {
+	l, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return l
+}
+
+func TestExtractTimezoneFromDsn(t *testing.T) {
+	type test struct {
+		dsn         string
+		loc         *time.Location
+		shouldError bool
+	}
+
+	tests := []test{
+		{dsn: "", loc: nil, shouldError: false},
+		{
+			dsn:         "Driver=something;SSP_timezone=America/Los_Angeles;",
+			loc:         loc(t, "America/Los_Angeles"),
+			shouldError: false,
+		},
+		{
+			dsn:         "Driver=something;SSP_timezone=America/New_York;ApplySSPWithQueries=0;",
+			loc:         loc(t, "America/New_York"),
+			shouldError: false,
+		},
+		{
+			dsn:         "Driver=something;SSP_timezone=;ApplySSPWithQueries=0;",
+			loc:         loc(t, "UTC"),
+			shouldError: false,
+		},
+		{
+			dsn:         "Driver=something;ApplySSPWithQueries=0;",
+			loc:         nil,
+			shouldError: false,
+		},
+		{
+			dsn:         "Driver=something;SSP_timezone=GMT-8;ApplySSPWithQueries=0;",
+			loc:         nil,
+			shouldError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := extractTimezoneFromDsn(tc.dsn)
+		if tc.shouldError && err == nil {
+			t.Errorf("Expected error, but got none")
+		} else if !tc.shouldError && err != nil {
+			t.Error(err)
+		}
+
+		if res.String() != tc.loc.String() {
+			t.Errorf("Expected %s but got %s", tc.loc, res)
+		}
+	}
+}


### PR DESCRIPTION
By default, the golang ODBC library treats all timestamp values (returned from the driver as a struct containing the year, month, day, etc.) as UTC, regardless of the actual session timezone. It's possible to override this setting, however, the timezone must be set as a global variable. Instead, we need to extract the session timezone from the DSN, so that we can set the timezone on a per-connection basis.